### PR TITLE
Forward declare UTextures so TextureManager.h compiles properly

### DIFF
--- a/Source/ImGui/Private/TextureManager.h
+++ b/Source/ImGui/Private/TextureManager.h
@@ -6,7 +6,7 @@
 #include <Textures/SlateShaderResource.h>
 #include <UObject/WeakObjectPtr.h>
 
-
+class UTexture;
 class UTexture2D;
 
 // Index type to be used as a texture handle.


### PR DESCRIPTION
TextureManager references some UTexture WeakPtr and I had a compilation error in my project, this fixes that.